### PR TITLE
do not process commands in blacklisted channel ids

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -5,6 +5,9 @@ module.exports = (client, message) => {
   // Ignore messages not starting with the prefix (in config.json)
   if (message.content.indexOf(client.config.prefix) !== 0) { return; }
 
+  // Ignore messages sent to blacklisted channel ids
+  if (client.config.blacklisted_channels.includes(message.channel.id)) { return; }
+
   // Parse the input into the command and arguments.
   const args = message.content.slice(client.config.prefix.length).trim().split(/ +/g);
   const command = args.shift().toLowerCase();


### PR DESCRIPTION
The bot will ignore all `prefix` commands in `blacklisted_channels`.

Add the following to `config.js`:

```
  blacklisted_channels: ['<CHANNEL_ID>']
```
... replacing `<CHANNEL_ID>` with the id(s) of the blacklisted channels.